### PR TITLE
Switch from a cluster to shard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,6 @@ async fn main() -> Result<()> {
 
                 let res = events_tx
                     .send(Event::AdventOfCode(Message {
-                        shard_id: 0,
                         channel_id,
                         author: None,
                     }))

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,6 @@ pub enum Event {
 
 #[derive(Debug)]
 pub struct Message {
-    pub shard_id: u64,
     pub channel_id: u64,
     pub author: Option<Author>,
 }


### PR DESCRIPTION
Simply replace the `Cluster` with a `Shard` as this is not a huge bot.

The cluster setup is more meant to be for huge setups when being registered on thousands of guilds/servers. The shard is recommended when the system is connected to up to 2000 guilds as described in the [readme](https://github.com/twilight-rs/twilight/tree/main/gateway).
﻿