### PR TITLE
Complete current cron scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cron",
  "dotenv",
  "futures-util",
+ "humantime",
  "log",
  "reqwest",
  "serde",
@@ -550,6 +551,12 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.43"
 cached = "0.26.2"
-cron = "0.9.0"
 chrono = "0.4.19"
 chrono-humanize = "0.2.1"
 cookie = "0.15.1"
+cron = "0.9.0"
 dotenv = "0.15.0"
 futures-util = "0.3.16"
+humantime = "2.1.0"
 log = "0.4.14"
 reqwest = { version = "0.11.4", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.129", features = ["derive"] }

--- a/config/auth.toml
+++ b/config/auth.toml
@@ -9,7 +9,7 @@ event= 2021
 bot_token = ""
 
 [discord.schedule]
-#          sec  min   hour   day of month   month   day of week   year 
+#          sec  min   hour   day of month   month   day of week   year
 #          0    0     0      *             *       *             *
 interval = "0 0 0 * * * *"
 channel_id = 0

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -76,8 +76,8 @@ async fn handle_events(
     sender.send(crate::models::Event::Shutdown).await.ok();
 }
 
-pub fn new_client(settings: &Discord) -> HttpClient {
-    HttpClient::new(settings.bot_token.clone())
+pub fn new_client(token: String) -> HttpClient {
+    HttpClient::new(token)
 }
 
 impl From<Message> for crate::models::Message {


### PR DESCRIPTION
Complete the current WIP cron implementation, fixing the scheduling bugs and reorganizing the code a bit.

Also:
- Slightly adjust the passing around of settings to avoid extra allocations.
- Remove `unwrap()` calls and handle errors instead.
