### PR TITLE
Improve Dockerfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,22 +242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,10 +608,10 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -838,12 +822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
 name = "ordered-float"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,32 +1018,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi",
-]
 
 [[package]]
 name = "sct"
@@ -1075,29 +1031,6 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1591,7 +1524,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
- "tracing",
  "twilight-gateway-queue",
  "twilight-http",
  "twilight-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ dotenv = "0.15.0"
 futures-util = "0.3.18"
 humantime = "2.1.0"
 log = "0.4.14"
-reqwest = { version = "0.11.6", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.6", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 serde = { version = "1.0.130", features = ["derive"] }
 simplelog = "0.11.0"
 tokio = { version = "1.14.0", features = ["fs", "macros", "rt-multi-thread", "signal"] }
 toml = "0.5.8"
 twilight-cache-inmemory = "0.7.2"
 twilight-embed-builder = "0.7.1"
-twilight-gateway = "0.7.1"
-twilight-http = "0.7.2"
+twilight-gateway = { version = "0.7.1", default-features = false, features = ["rustls-webpki-roots", "zlib-stock"] }
+twilight-http = { version = "0.7.2", default-features = false, features = ["decompression", "rustls-webpki-roots"] }
 twilight-model = "0.7.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-FROM clux/muslrust:stable as builder
+FROM rust:1.56 as builder
+
+WORKDIR /volume
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends musl-tools=1.2.2-1 && \
+    rustup target add x86_64-unknown-linux-musl
 
 COPY src/ src/
 COPY Cargo.lock Cargo.toml ./
 
-RUN cargo install --locked --path .
+RUN cargo build --release --target x86_64-unknown-linux-musl && \
+    strip --strip-all target/x86_64-unknown-linux-musl/release/aoc_bot
 
-FROM alpine:3.12
+FROM alpine:3.14 as newuser
+
+RUN echo "aoc_bot:x:1000:" > /tmp/group && \
+    echo "aoc_bot:x:1000:1000::/dev/null:/sbin/nologin" > /tmp/passwd
+
+FROM scratch
 
 WORKDIR /data
 
-COPY config/ /data/config/
-COPY --from=builder /root/.cargo/bin/aoc_bot /bin/
+COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/aoc_bot /bin/
+COPY --from=newuser /tmp/group /tmp/passwd /etc/
 
 STOPSIGNAL SIGINT
+USER aoc_bot
 
 ENTRYPOINT ["/bin/aoc_bot"]

--- a/config/auth.toml
+++ b/config/auth.toml
@@ -13,4 +13,3 @@ bot_token = ""
 #          0    0     0      *             *       *             *
 interval = "0 0 0 * * * *"
 channel_id = 1
-

--- a/config/log.toml
+++ b/config/log.toml
@@ -1,7 +1,3 @@
 # To disable any logger, comment out or remove its whole section.
 [terminal]
 filter = "info"
-
-[file]
-filter = "info"
-path = "aocbot.log"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,15 @@ async fn main() -> Result<()> {
     // Loading .env file
     dotenv::dotenv().ok();
     // Load settings file
-    let settings = Settings::new().await?;
+    let settings = Settings::new().await.context("failed loading settings")?;
 
-    setup_logger(&settings.logging)?;
+    setup_logger(&settings.logging).context("failed setting up logger")?;
 
     info!("Starting ...");
     let (events_tx, mut events_rx) = mpsc::channel(1);
-    discord::start(&settings.discord, events_tx.clone()).await?;
+    discord::start(&settings.discord, events_tx.clone())
+        .await
+        .context("failed starting Discord listener")?;
 
     if let Some(schedule) = settings.discord.schedule {
         debug!("Setting up scheduled leaderboard messages");


### PR DESCRIPTION
This PR enhances several parts of the current Dockerfile that I initially wrote a long time ago.

1. It steps down from the root user, improving security in case someone might hack into the container.
2. The base image is `scratch` now, further improving security and image size. It now has literally nothing in it besides the binary and minimal user config needed for point 1.
3. Using the official Rust image instead of a 3rd party image. Ther is `rust:1.56-alpine` as well but cross compiling turned out to be significantly faster for some reason.
4. Config files are not included in the image anymore and defaults are defined in code instead.
﻿