### PR TITLE
Add .editorconfig for common formatting settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
The `.editorconfig` file is a popular settings file that defines a few common formatting settings for different files. It is supported by most IDEs so that at least basic settings are automatically picked up by most contributors' editors, reducing the chance for accidental formatting issues.

More details about the editorconfig concept: https://editorconfig.org